### PR TITLE
small fix for README.md to remove the payload from the GET index request

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,6 @@ $ curl \
     -H 'X-Pets-Token: <your-token>' \
     -H 'Accept: application/json' \
     -H 'Content-Type: application/json' \
-    -d '{ "name": "Fluffy", "strength": 12, "intelligence": 22, "speed": 21, "integrity": 66 }' \
     https://wunder-pet-api-staging.herokuapp.com/pets
 
 [{"id":"d44c512d-65f2-4173-a7aa-a1ebc8cc52d6","name":"Fluffy","strength":12,"intelligence":22,"speed":21,"integrity":66}, ...]


### PR DESCRIPTION
This PR removes the payload (which causes an error response) from the GET index example curl command in README.md.